### PR TITLE
Fix code block detection in markdown validator

### DIFF
--- a/client/src/lib/markdown-parser.ts
+++ b/client/src/lib/markdown-parser.ts
@@ -85,8 +85,8 @@ export function validateMarkdown(markdown: string): {
   const lines = markdown.split('\n');
 
   // Check for unclosed code blocks
-  const codeBlocks = markdown.match(/```/g);
-  if (codeBlocks && codeBlocks.length % 2 !== 0) {
+  const fenceLines = lines.filter((line) => line.trim().startsWith('```'));
+  if (fenceLines.length % 2 !== 0) {
     errors.push({
       type: 'error',
       message: 'Unclosed code block detected',


### PR DESCRIPTION
## Summary
- fix unclosed code block detection by only counting fence lines

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_683f4efc1a548322a1a12f00e7c7d2c8