### PR TITLE
Add structured note JSON output

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "marked": "^15.0.12",
     "memorystore": "^1.6.7",
     "multer": "^2.0.0",
+    "yaml": "^2.6.0",
     "next-themes": "^0.4.6",
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -29,9 +29,7 @@ export const convertMarkdownResponseSchema = z.object({
     jsonSize: z.string(),
     processTime: z.string(),
   }),
-  metadata: z.object({
-    word_count: z.number(),
-  }),
+  metadata: z.record(z.any()),
 });
 
 export type ConvertMarkdownRequest = z.infer<typeof convertMarkdownSchema>;


### PR DESCRIPTION
## Summary
- support YAML frontmatter and wiki links in server parser
- build comprehensive note metadata
- return note data with id, title, metadata and content
- allow arbitrary metadata in response schema
- add yaml dependency for server

## Testing
- `npm run check` *(fails: Cannot find type definition file)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68409b22231c8322991d9ca0a455770d