### PR TITLE
Add note editor with backlinks support

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,11 +5,13 @@ import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ThemeProvider } from "@/components/theme-provider";
 import ConverterPage from "@/pages/converter";
+import NoteEditorPage from "@/pages/note-editor";
 
 function Router() {
   return (
     <Switch>
       <Route path="/" component={ConverterPage} />
+      <Route path="/notes/:id" component={NoteEditorPage} />
       <Route component={ConverterPage} />
     </Switch>
   );

--- a/client/src/pages/note-editor.tsx
+++ b/client/src/pages/note-editor.tsx
@@ -1,0 +1,118 @@
+import { useState, useEffect } from "react";
+import { useRoute, Link } from "wouter";
+import MarkdownInput from "@/components/markdown-input";
+import JsonOutput from "@/components/json-output";
+import { Button } from "@/components/ui/button";
+import { apiRequest } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+import type { SaveNoteRequest, GetNoteResponse } from "@shared/schema";
+
+export default function NoteEditorPage() {
+  const [match, params] = useRoute<{ id: string }>("/notes/:id");
+  const { toast } = useToast();
+  const [title, setTitle] = useState("");
+  const [markdown, setMarkdown] = useState("");
+  const [jsonOutput, setJsonOutput] = useState<any>(null);
+  const [backlinks, setBacklinks] = useState<any[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const noteId = params?.id && params.id !== "new" ? Number(params.id) : undefined;
+
+  useEffect(() => {
+    if (noteId !== undefined) {
+      apiRequest("GET", `/api/notes/${noteId}`)
+        .then((r) => r.json() as Promise<GetNoteResponse>)
+        .then((data) => {
+          setTitle(data.note.title);
+          setMarkdown(data.note.markdownContent);
+          setJsonOutput(JSON.parse(data.note.jsonOutput));
+          setBacklinks(data.backlinks);
+        })
+        .catch((err) =>
+          toast({
+            title: "Failed to load note",
+            description: err.message,
+            variant: "destructive",
+          }),
+        );
+    }
+  }, [noteId]);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      if (markdown.trim()) {
+        apiRequest("POST", "/api/convert", { markdown })
+          .then((r) => r.json())
+          .then((data) => setJsonOutput(data.json))
+          .catch(() => {});
+      } else {
+        setJsonOutput(null);
+      }
+    }, 500);
+    return () => clearTimeout(timeout);
+  }, [markdown]);
+
+  const handleSave = async () => {
+    if (!title.trim() || !markdown.trim()) {
+      toast({
+        title: "Missing content",
+        description: "Title and markdown are required",
+        variant: "destructive",
+      });
+      return;
+    }
+    setIsSaving(true);
+    const payload: SaveNoteRequest = { id: noteId, title, markdown };
+    try {
+      const res = await apiRequest("POST", "/api/notes", payload);
+      const data = await res.json();
+      setJsonOutput(data.json);
+      toast({ title: "Note saved" });
+    } catch (err: any) {
+      toast({
+        title: "Save failed",
+        description: err.message,
+        variant: "destructive",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <input
+          className="border rounded p-2 w-full mr-4"
+          placeholder="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <Button onClick={handleSave} disabled={isSaving}>
+          {isSaving ? "Saving..." : "Save"}
+        </Button>
+      </div>
+      <div className="grid md:grid-cols-2 gap-4">
+        <MarkdownInput
+          value={markdown}
+          onChange={setMarkdown}
+          onConvert={() => {}}
+          isLoading={false}
+        />
+        <JsonOutput jsonData={jsonOutput} isLoading={false} />
+      </div>
+      {backlinks.length > 0 && (
+        <div>
+          <h3 className="font-semibold mb-2">Backlinks</h3>
+          <ul className="list-disc pl-5 space-y-1">
+            {backlinks.map((b) => (
+              <li key={b.id}>
+                <Link href={`/notes/${b.id}`}>{b.title}</Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/shared/parser.ts
+++ b/shared/parser.ts
@@ -1,0 +1,251 @@
+export interface ParseResult {
+  json: any;
+  stats: {
+    elements: number;
+    jsonSize: string;
+    processTime: string;
+  };
+  metadata: {
+    word_count: number;
+    reading_time: number;
+    tags: string[];
+    wikilinks: string[];
+    created_at: string;
+    updated_at: string;
+  };
+}
+
+export function countWords(markdown: string): number {
+  let text = markdown.replace(/```[\s\S]*?```/g, " ");
+  text = text.replace(/`[^`]*`/g, " ");
+  text = text.replace(/!\[[^\]]*\]\([^)]*\)/g, " ");
+  text = text.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1");
+  text = text.replace(/^\s*>\s?/gm, "");
+  text = text.replace(/^\s{0,3}#{1,6}\s+/gm, "");
+  text = text.replace(/^\s*[-*+]\s+/gm, "");
+  text = text.replace(/^\s*\d+\.\s+/gm, "");
+  text = text.replace(/[*_~]/g, "");
+  text = text.replace(/<[^>]+>/g, " ");
+  text = text.replace(/[\n\r\t]+/g, " ");
+  text = text.replace(/\s+/g, " ").trim();
+  return text ? text.split(/\s+/).length : 0;
+}
+
+function parseInlineElements(text: string): any[] {
+  const elements: any[] = [];
+  const strongRegex = /\*\*(.*?)\*\*/g;
+  const emRegex = /\*(.*?)\*/g;
+  const linkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
+  const codeRegex = /`([^`]+)`/g;
+  let lastIndex = 0;
+  const matches: Array<{ type: string; content: string; url?: string; start: number; end: number }> = [];
+  let match: RegExpExecArray | null;
+  strongRegex.lastIndex = 0;
+  while ((match = strongRegex.exec(text)) !== null) {
+    matches.push({ type: 'strong', content: match[1], start: match.index, end: match.index + match[0].length });
+  }
+  emRegex.lastIndex = 0;
+  while ((match = emRegex.exec(text)) !== null) {
+    if (!matches.some(m => match!.index >= m.start && match!.index < m.end)) {
+      matches.push({ type: 'emphasis', content: match[1], start: match.index, end: match.index + match[0].length });
+    }
+  }
+  linkRegex.lastIndex = 0;
+  while ((match = linkRegex.exec(text)) !== null) {
+    matches.push({ type: 'link', content: match[1], url: match[2], start: match.index, end: match.index + match[0].length });
+  }
+  codeRegex.lastIndex = 0;
+  while ((match = codeRegex.exec(text)) !== null) {
+    matches.push({ type: 'code', content: match[1], start: match.index, end: match.index + match[0].length });
+  }
+  matches.sort((a, b) => a.start - b.start);
+  matches.forEach(match => {
+    if (match.start > lastIndex) {
+      const textContent = text.slice(lastIndex, match.start);
+      if (textContent.trim()) {
+        elements.push({ type: 'text', content: textContent });
+      }
+    }
+    if (match.type === 'link') {
+      elements.push({ type: 'link', content: match.content, url: match.url });
+    } else {
+      elements.push({ type: match.type, content: match.content });
+    }
+    lastIndex = match.end;
+  });
+  if (lastIndex < text.length) {
+    const remaining = text.slice(lastIndex);
+    if (remaining.trim()) {
+      elements.push({ type: 'text', content: remaining });
+    }
+  }
+  if (elements.length === 0 && text.trim()) {
+    return [{ type: 'text', content: text.replace(/<[^>]*>/g, '') }];
+  }
+  return elements;
+}
+
+export function parseMarkdownToStructuredJson(markdown: string): ParseResult {
+  const startTime = Date.now();
+  let tags: string[] = [];
+  let wikilinks: string[] = [];
+  let createdAt = new Date();
+  let updatedAt = new Date();
+  const fmMatch = markdown.match(/^---\n([\s\S]*?)\n---/);
+  if (fmMatch) {
+    const fm = fmMatch[1];
+    const fmLines = fm.split(/\n+/);
+    for (const line of fmLines) {
+      const [rawKey, ...rest] = line.split(":");
+      if (!rawKey || rest.length === 0) continue;
+      const key = rawKey.trim().toLowerCase();
+      const value = rest.join(":").trim();
+      if (key === 'tags') {
+        if (value.startsWith('[') && value.endsWith(']')) {
+          tags.push(
+            ...value
+              .slice(1, -1)
+              .split(/[,\s]+/)
+              .map((t) => t.replace(/^["'\-\s]+|["'\s]+$/g, ''))
+              .filter(Boolean)
+          );
+        } else {
+          tags.push(
+            ...value
+              .split(/[,\s]+/)
+              .map((t) => t.replace(/^["'\-\s]+|["'\s]+$/g, ''))
+              .filter(Boolean)
+          );
+        }
+      } else if (key === 'created' || key === 'created_at') {
+        const d = new Date(value);
+        if (!isNaN(d.getTime())) createdAt = d;
+      } else if (key === 'updated' || key === 'updated_at') {
+        const d = new Date(value);
+        if (!isNaN(d.getTime())) updatedAt = d;
+      }
+    }
+    markdown = markdown.slice(fmMatch[0].length).trimStart();
+  }
+  const tagRegex = /(^|\s)#([A-Za-z0-9_-]+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = tagRegex.exec(markdown)) !== null) {
+    tags.push(m[2]);
+  }
+  const wikiRegex = /\[\[([^\]]+)\]\]/g;
+  while ((m = wikiRegex.exec(markdown)) !== null) {
+    wikilinks.push(m[1].trim());
+  }
+  tags = Array.from(new Set(tags));
+  wikilinks = Array.from(new Set(wikilinks));
+  const elements: any[] = [];
+  let elementCount = 0;
+  const lines = markdown.split('\n');
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i].trim();
+    if (!line) {
+      i++;
+      continue;
+    }
+    const headerMatch = line.match(/^(#{1,6})\s+(.+)$/);
+    if (headerMatch) {
+      elements.push({ type: 'heading', level: headerMatch[1].length, content: headerMatch[2] });
+      elementCount++;
+      i++;
+      continue;
+    }
+    if (line.startsWith('```')) {
+      const langMatch = line.match(/^```(\w+)?/);
+      const language = langMatch?.[1] || 'text';
+      const codeLines: string[] = [];
+      i++;
+      while (i < lines.length && !lines[i].trim().startsWith('```')) {
+        codeLines.push(lines[i]);
+        i++;
+      }
+      elements.push({ type: 'code_block', language, content: codeLines.join('\n') });
+      elementCount++;
+      i++;
+      continue;
+    }
+    if (line.startsWith('>')) {
+      const content = line.substring(1).trim();
+      elements.push({ type: 'blockquote', content });
+      elementCount++;
+      i++;
+      continue;
+    }
+    if (line.match(/^[-*_]{3,}$/)) {
+      elements.push({ type: 'horizontal_rule' });
+      elementCount++;
+      i++;
+      continue;
+    }
+    const unorderedListMatch = line.match(/^[\s]*[-*+]\s+(.+)$/);
+    if (unorderedListMatch) {
+      const items: any[] = [];
+      while (i < lines.length) {
+        const currentLine = lines[i].trim();
+        const listMatch = currentLine.match(/^[\s]*[-*+]\s+(.+)$/);
+        if (listMatch) {
+          items.push({ type: 'list_item', content: listMatch[1] });
+          i++;
+        } else if (currentLine === '') {
+          i++;
+        } else {
+          break;
+        }
+      }
+      elements.push({ type: 'list', ordered: false, items });
+      elementCount++;
+      continue;
+    }
+    const orderedListMatch = line.match(/^[\s]*\d+\.\s+(.+)$/);
+    if (orderedListMatch) {
+      const items: any[] = [];
+      while (i < lines.length) {
+        const currentLine = lines[i].trim();
+        const listMatch = currentLine.match(/^[\s]*\d+\.\s+(.+)$/);
+        if (listMatch) {
+          items.push({ type: 'list_item', content: listMatch[1] });
+          i++;
+        } else if (currentLine === '') {
+          i++;
+        } else {
+          break;
+        }
+      }
+      elements.push({ type: 'list', ordered: true, items });
+      elementCount++;
+      continue;
+    }
+    const children = parseInlineElements(line);
+    if (children.length === 1 && children[0].type === 'text') {
+      elements.push({ type: 'paragraph', content: children[0].content });
+    } else {
+      elements.push({ type: 'paragraph', children });
+    }
+    elementCount++;
+    i++;
+  }
+  const endTime = Date.now();
+  const processTime = ((endTime - startTime) / 1000).toFixed(3) + 's';
+  const result = { type: 'document', children: elements };
+  const jsonString = JSON.stringify(result, null, 2);
+  const jsonSize = (jsonString.length / 1024).toFixed(1) + ' KB';
+  const wordCount = countWords(markdown);
+  const readingTime = Math.max(1, Math.ceil(wordCount / 200));
+  return {
+    json: result,
+    stats: { elements: elementCount, jsonSize, processTime },
+    metadata: {
+      word_count: wordCount,
+      reading_time: readingTime,
+      tags,
+      wikilinks,
+      created_at: createdAt.toISOString(),
+      updated_at: updatedAt.toISOString(),
+    },
+  };
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, serial, integer, boolean, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, text, serial, timestamp, integer } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -9,15 +9,40 @@ export const conversions = pgTable("conversions", {
   createdAt: timestamp("created_at").defaultNow(),
 });
 
+export const notes = pgTable("notes", {
+  id: serial("id").primaryKey(),
+  title: text("title").notNull(),
+  markdownContent: text("markdown_content").notNull(),
+  jsonOutput: text("json_output").notNull(),
+  tags: text("tags"),
+  wikilinks: text("wikilinks"),
+  wordCount: integer("word_count"),
+  readingTime: integer("reading_time"),
+  createdAt: timestamp("created_at").defaultNow(),
+  updatedAt: timestamp("updated_at").defaultNow(),
+});
+
 export const insertConversionSchema = createInsertSchema(conversions).pick({
   markdownContent: true,
   jsonOutput: true,
 });
 
+export const insertNoteSchema = createInsertSchema(notes).pick({
+  title: true,
+  markdownContent: true,
+  jsonOutput: true,
+  tags: true,
+  wikilinks: true,
+  wordCount: true,
+  readingTime: true,
+});
+
 export type InsertConversion = z.infer<typeof insertConversionSchema>;
 export type Conversion = typeof conversions.$inferSelect;
 
-// API request/response schemas
+export type InsertNote = typeof notes.$inferInsert;
+export type Note = typeof notes.$inferSelect;
+
 export const convertMarkdownSchema = z.object({
   markdown: z.string().min(1, "Markdown content is required"),
 });
@@ -31,8 +56,47 @@ export const convertMarkdownResponseSchema = z.object({
   }),
   metadata: z.object({
     word_count: z.number(),
+    reading_time: z.number(),
+    tags: z.array(z.string()),
+    wikilinks: z.array(z.string()),
+    created_at: z.string(),
+    updated_at: z.string(),
   }),
 });
 
 export type ConvertMarkdownRequest = z.infer<typeof convertMarkdownSchema>;
 export type ConvertMarkdownResponse = z.infer<typeof convertMarkdownResponseSchema>;
+
+export const saveNoteSchema = z.object({
+  id: z.number().optional(),
+  title: z.string().min(1, "Title is required"),
+  markdown: z.string().min(1, "Markdown content is required"),
+  tags: z.array(z.string()).optional(),
+});
+
+export const saveNoteResponseSchema = convertMarkdownResponseSchema.extend({
+  note: z.record(z.any()),
+});
+
+export type SaveNoteRequest = z.infer<typeof saveNoteSchema>;
+export type SaveNoteResponse = z.infer<typeof saveNoteResponseSchema>;
+
+export const noteSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  markdownContent: z.string(),
+  jsonOutput: z.string(),
+  tags: z.string().nullable(),
+  wikilinks: z.string().nullable(),
+  wordCount: z.number().nullable(),
+  readingTime: z.number().nullable(),
+  createdAt: z.any(),
+  updatedAt: z.any(),
+});
+
+export const getNoteResponseSchema = z.object({
+  note: noteSchema,
+  backlinks: z.array(noteSchema),
+});
+
+export type GetNoteResponse = z.infer<typeof getNoteResponseSchema>;


### PR DESCRIPTION
## Summary
- refactor markdown parser into shared module
- implement backlinks query in storage and server route
- expose API to fetch note with backlinks
- add note editor page showing markdown and JSON
- route `/notes/:id` to note editor

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6840a5d2f8c8832284ebe60b478e1d53